### PR TITLE
애니메이션 수정

### DIFF
--- a/YunoGame/Game/Object/UnitPiece.h
+++ b/YunoGame/Game/Object/UnitPiece.h
@@ -24,7 +24,7 @@ private:
 public:
     void InsertQ(PGridCmd targetPos);
     void SetWho(GamePiece type);
-    void SetDir(Direction dir, bool isAnim = true);
+    void SetDir(Direction dir, bool isAnim = true, float speed = 2.f);
     void SetFlashColor(Float4 color, int count, float blinkTime);
     void PlayAttack();
     void SetDead();
@@ -53,15 +53,18 @@ private:
     bool isFlashing = false;
 
     // 이동
+    float moveOffset = 0.2f;
     XMVECTOR m_Target{};
     XMVECTOR m_Start{};
     float m_Dist = 0;
     float m_speed = 10;
     float m_fixSpeed = 1;
-    float m_AnimTime = 0.f;
+    float m_moveTime = 0.f;
     bool isMoving = false;
 
     // 회전
+    //float rotOffset = XMConvertToRadians(35.f);
+    Direction m_dir = Direction::None;
     float m_rotTime = 0.f;
     float m_rotSpeed = 2.f;
     float m_yaw = atan2(0, 1);

--- a/YunoGame/System/PlayGridSystem.cpp
+++ b/YunoGame/System/PlayGridSystem.cpp
@@ -159,79 +159,6 @@ void PlayGridSystem::CreateTileAndPiece(float x, float y, float z)
     for (const auto& w : wData)
     {
         CreatePiece(w);
-        //team = (w.pId == m_pID) ? Team::Ally : Team::Enemy;
-
-        //dir = (w.pId == 1) ? Direction::Right : Direction::Left;
-        //auto cellPos = GetCellByID(w.currentTile);
-        //cx = cellPos.x;     cy = cellPos.y;
-
-        //auto [px, pz] = m_grids[(int)m_nowG]->CellToWorld(cx, cy);
-
-        //// 타일 상태 갱신
-        //m_tiles[w.currentTile].to = (team == Team::Ally) ?
-        //    TileOccupy{ TileOccuType::Ally_Occupied, (w.slotId == 1) ? TileWho::Ally1 : TileWho::Ally2 } :
-        //    TileOccupy{ TileOccuType::Enemy_Occupied, (w.slotId == 1) ? TileWho::Enemy1 : TileWho::Enemy2 };
-
-        //GamePiece gp = (GamePiece)m_tiles[w.currentTile].to.who;
-        //PieceInfo pieceInfo{};
-
-        //UnitPiece* pPiece = nullptr;
-        //if (w.weaponId == 2)
-        //{
-        //    pPiece = m_manager->CreateObject<UnitPiece>(
-        //        L"Weapon", XMFLOAT3(px, m_wy, pz));
-
-        //    auto pChakram1 = m_manager->CreateObjectFromFile<UnitPiece>(
-        //        L"Chakram1", XMFLOAT3(0, 0, 0), L"../Assets/fbx/weapon/Chakram/Chakram01.fbx");
-        //    pChakram1->AddAnimationClip("idle", L"../Assets/fbx/Animation/idle/chakram_01_idle.fbx");
-        //    pPiece->Attach(pChakram1);
-
-        //    auto pChakram2 = m_manager->CreateObjectFromFile<UnitPiece>(
-        //        L"Chakram2", XMFLOAT3(0, 0, 0), L"../Assets/fbx/weapon/Chakram/Chakram02.fbx");
-        //    pChakram2->AddAnimationClip("idle", L"../Assets/fbx/Animation/idle/chakram_02_idle.fbx");
-        //    pPiece->Attach(pChakram2);
-
-        //    pieceInfo = PieceInfo{ pPiece->GetID(), dir, team };
-        //    pieceInfo.subIds.push_back(pChakram1->GetID());
-        //    pieceInfo.subIds.push_back(pChakram2->GetID());
-
-        //    m_gridBox->Attach(pPiece);
-        //}
-        //else
-        //{
-        //    std::wstring fileName = GetWeaponFileName(w.weaponId);
-        //    pPiece = m_manager->CreateObjectFromFile<UnitPiece>(L"Weapon", XMFLOAT3(px, m_wy, pz), fileName);
-        //}
-        //
-        ////// weapon 구별을 위한 임시
-        //switch (w.weaponId)
-        //{
-        //case 1:
-        //    pPiece->AddAnimationClip("idle", L"../Assets/fbx/Animation/idle/blaster_idle.fbx");
-        //    pPiece->AddAnimationClip("attack", L"../Assets/fbx/Animation/attack/Blaster_attack.fbx");
-        //    break;
-        //case 3:
-        //    pPiece->AddAnimationClip("idle", L"../Assets/fbx/Animation/idle/drill_idle.fbx");
-        //    break;
-        //case 4:
-        //    pPiece->AddAnimationClip("idle", L"../Assets/fbx/Animation/idle/scythe_idle.fbx");
-        //    break;
-        //case 5:
-        //    pPiece->AddAnimationClip("idle", L"../Assets/fbx/Animation/idle/impactor_idle.fbx");
-        //    pPiece->AddAnimationClip("attack", L"../Assets/fbx/Animation/attack/Impactor_attack.fbx");
-        //    break;
-        //case 6:
-        //    pPiece->AddAnimationClip("idle", L"../Assets/fbx/Animation/idle/blade_idle.fbx");
-        //    break;
-        //pPiece->SetWho(gp);
-
-        //pPiece->SetDir(dir, false);
-
-        //// 기물 정보 등록
-        //m_pieces.emplace(gp, PieceInfo{pPiece->GetID(), dir, team });
-
-        //// 빈 박스에 자식 객체로 등록. (for 정리)
-        //m_gridBox->Attach(pPiece);
 
         int usID = GetUnitID(w.pId, w.slotId);
         m_UnitStates[usID] = {
@@ -272,11 +199,13 @@ void PlayGridSystem::CreatePiece(const Wdata& w)
          auto pChakram1 = m_manager->CreateObjectFromFile<UnitPiece>(
              L"Chakram1", XMFLOAT3(0, 0, 0), L"../Assets/fbx/weapon/Chakram/Chakram01.fbx");
          pChakram1->AddAnimationClip("idle", L"../Assets/fbx/Animation/idle/chakram_01_idle.fbx");
+         //pChakram1->AddAnimationClip("attack", L"../Assets/fbx/Animation/attack/Chakram_attack_01.fbx");
          pPiece->Attach(pChakram1);
 
          auto pChakram2 = m_manager->CreateObjectFromFile<UnitPiece>(
              L"Chakram2", XMFLOAT3(0, 0, 0), L"../Assets/fbx/weapon/Chakram/Chakram02.fbx");
          pChakram2->AddAnimationClip("idle", L"../Assets/fbx/Animation/idle/chakram_02_idle.fbx");
+         //pChakram2->AddAnimationClip("attack", L"../Assets/fbx/Animation/attack/Chakram_attack_02.fbx");
          pPiece->Attach(pChakram2);
 
          pieceInfo = PieceInfo{ pPiece->GetID(), dir, team };
@@ -303,20 +232,23 @@ void PlayGridSystem::CreatePiece(const Wdata& w)
      {
      case 1:
          pPiece->AddAnimationClip("idle", L"../Assets/fbx/Animation/idle/blaster_idle.fbx");
-         pPiece->AddAnimationClip("attack", L"../Assets/fbx/Animation/attack/Blaster_attack.fbx");
+         //pPiece->AddAnimationClip("attack", L"../Assets/fbx/Animation/attack/Blaster_attack.fbx");
          break;
      case 3:
          pPiece->AddAnimationClip("idle", L"../Assets/fbx/Animation/idle/drill_idle.fbx");
+         //pPiece->AddAnimationClip("attack", L"../Assets/fbx/Animation/attack/Breacher_attack.fbx");
          break;
      case 4:
          pPiece->AddAnimationClip("idle", L"../Assets/fbx/Animation/idle/scythe_idle.fbx");
+         pPiece->AddAnimationClip("move", L"../Assets/fbx/Animation/attack/scythe_move.fbx");
          break;
      case 5:
          pPiece->AddAnimationClip("idle", L"../Assets/fbx/Animation/idle/impactor_idle.fbx");
-         pPiece->AddAnimationClip("attack", L"../Assets/fbx/Animation/attack/Impactor_attack.fbx");
+         //pPiece->AddAnimationClip("attack", L"../Assets/fbx/Animation/attack/Impactor_attack.fbx");
          break;
      case 6:
          pPiece->AddAnimationClip("idle", L"../Assets/fbx/Animation/idle/blade_idle.fbx");
+         //pPiece->AddAnimationClip("attack", L"../Assets/fbx/Animation/attack/Cleaver_attack.fbx");
          break;
      }
      pPiece->SetWho(gp);
@@ -424,8 +356,8 @@ void PlayGridSystem::CheckPacket(float dt)
 
         const CardType cardType = cardData.m_type;
         
-        if (cardType == CardType::Attack)    m_pktTime = 6.f;
-        else if (cardType == CardType::Utility)    m_pktTime = 10.5f;
+        if (cardType == CardType::Attack)    m_pktTime = attackPktTime;
+        else if (cardType == CardType::Utility)    m_pktTime = utilityPktTime;
         //---------------------------------------------------
         ApplyActionOrder(order, mainUnit, runTimeCardID, (Direction)dir);
     }
@@ -474,6 +406,23 @@ void PlayGridSystem::UpdateAttackSequence(float dt)
         }
 
         if (!as.phaseStarted) break;
+
+        auto attackerIt = m_pieces.find(as.attacker);
+        if (attackerIt == m_pieces.end())
+        {
+            as.attackPhase = AttackPhase::Over;
+            break;
+        }
+
+        const auto& pieceInfo = attackerIt->second;
+        auto pPiece = static_cast<UnitPiece*>(m_manager->FindObject(pieceInfo.id));
+        if (pPiece == nullptr)
+        {
+            as.attackPhase = AttackPhase::Over;
+            break;
+        }
+
+        pPiece->SetDir(as.dir, true, 3.f);
 
         const auto& tiles = as.tileIDs;
         for (int i = 0; i < tiles.size(); i++)
@@ -821,6 +770,7 @@ bool PlayGridSystem::ApplyAttackChanges
     // 공격 시퀀스 채워넣기
     auto& as = m_attackSequence;
     as.attacker = whichPiece;
+    as.dir = dir;
     as.tileIDs = targetTileIDs;
     as.attackPhase = AttackPhase::Alaram;
     as.phaseStarted = m_attackActive = true;

--- a/YunoGame/System/PlayGridSystem.h
+++ b/YunoGame/System/PlayGridSystem.h
@@ -36,6 +36,7 @@ inline void operator++(AttackPhase& a) { a = (AttackPhase)((uint8_t)a + 1); }
 struct AttackSequence
 {
     GamePiece attacker = GamePiece::None;   // 공격 기물
+    Direction dir = Direction::Same;
     std::vector<int> tileIDs;               // 피격 타일들
     std::vector<GamePiece> hitPieces;       // 피격 기물들
     AttackPhase attackPhase = AttackPhase::None;
@@ -175,7 +176,7 @@ private:
     // 시간 관련
     float moveDuration = 2.5f;
     float buffDuration = 2.f;
-    float attackDuration = 3.5f;
+    float attackDuration = 3.f;
 
     int tileFlashCount = 3;
     float tileFlashInterval = 0.3f;
@@ -184,6 +185,10 @@ private:
     float hitDuration = tileFlashDuration;    // 미정. 현재 tileFlashDuration과 동일.
 
     float attackAndMoveDuration = attackDuration + tileFlashDuration + hitDuration;
+    
+    float pktOffset = 0.5f;
+    float attackPktTime = attackAndMoveDuration + pktOffset;
+    float utilityPktTime = moveDuration + attackAndMoveDuration + buffDuration + pktOffset;
     
     // 공격 처리
     bool m_attackActive = false;


### PR DESCRIPTION
공격 방향에 따라 회전

move 애니메이션 있는 기물(낫만 잇음)은 이동 시 move 애니메이션 재생

시간하드 코딩해둔 거 멤버변수로 다 뺌
유틸리티에서 이동-공격-버프 중에 없는 단계는 패킷 타임에서 해당 시간만큼 빼도록 처리

## 📌 Summary (변경 요약)
- 변경 목적:
- 핵심 변경 내용:

---

## 🧩 Type of Change
해당되는 항목에 체크하세요.

- [ ] Feature (새 기능)
- [ ] Bug fix (버그 수정)
- [ ] Refactor (리팩토링)
- [ ] Chore (빌드/설정/구조 정리)
- [ ] Docs (문서 수정)

---

## 🔁 How to Test
1. 
2. 
3. 

---

## ✅ Checklist
- [ ] 빌드 성공
- [ ] 테스트 코드 및 불필요한 로그 제거
- [ ] 전방 선언 및 헤더 인클루드 점검
- [ ] 실행 테스트 완료 (Debug)
- [ ] 실행 테스트 완료 (Release)
