### PR TITLE
인게임 UI 수정 (체력텍스트/스태미나 게이지/카드 페이지/카운트다운·결과 배경)

### DIFF
--- a/YunoEngine/Private/Renderer/YunoRenderer.cpp
+++ b/YunoEngine/Private/Renderer/YunoRenderer.cpp
@@ -2800,6 +2800,8 @@ bool YunoRenderer::RegisterFont()
         m_Fonts.emplace(FontID::Default, std::move(font));
         font = std::make_unique<SpriteFont>(m_device.Get(), L"../Assets/Font/number.spritefont");
         m_Fonts.emplace(FontID::Number, std::move(font));
+        font = std::make_unique<SpriteFont>(m_device.Get(), L"../Assets/Font/SFAutomatonExt.spritefont");
+        m_Fonts.emplace(FontID::SFAutomatonExt, std::move(font));
     }
     catch (...) {
         return false;

--- a/YunoEngine/Public/Renderer/RenderTypes.h
+++ b/YunoEngine/Public/Renderer/RenderTypes.h
@@ -155,6 +155,7 @@ enum class FontID : uint8_t
 {
     Default = 0,
     Number = 1,
+    SFAutomatonExt = 2,
 
 
     Count

--- a/YunoGame/CountdownScene.cpp
+++ b/YunoGame/CountdownScene.cpp
@@ -7,6 +7,7 @@
 #include "CountdownImage.h"
 #include "Emoji.h"
 #include "AudioQueue.h"
+#include "UIWidgets.h"
 
 
 namespace
@@ -19,6 +20,13 @@ bool CountdownScene::OnCreateScene()
 {
     // UI 전용 씬
     m_uiManager->SetOrthoFlag(true);
+
+    // 카운트다운(3,2,1) 글씨 뒤 어두운 필터 (StandBy와 동일한 방식)
+    auto canvas = m_uiManager->GetCanvasSize();
+    CreateWidget<TextureImage>(L"CountdownBackGround",
+        L"../Assets/UI/WEAPON_SELECT/black_background.png",
+        XMFLOAT3(canvas.x * 0.5f, canvas.y * 0.5f, 0), UIDirection::Center);
+
     return true;
 }
 

--- a/YunoGame/Game/UI/CardSelectionPanel.cpp
+++ b/YunoGame/Game/UI/CardSelectionPanel.cpp
@@ -185,10 +185,10 @@ void CardSelectionPanel::CreateChild() {
     
     // 페이지 버튼
     {
-        m_pPageText = m_uiFactory.CreateChild<Text>(m_name + L"_PageNum", Float2(74, 66), XMFLOAT3(-100, -302, 0), 0, XMFLOAT3(1, 1, 1), UIDirection::Center, this);
+        m_pPageText = m_uiFactory.CreateChild<Text>(m_name + L"_PageNum", Float2(74, 66), XMFLOAT3(-64, -184, 0), 0, XMFLOAT3(1, 1, 1), UIDirection::Center, this);
         m_pPageText->SetText(std::to_wstring(m_curPage));
-        m_pPageText->SetTextScale(XMFLOAT3(1.5f, 1.5f, 1.5f));
-        m_pPageText->SetFont(FontID::Number);
+        m_pPageText->SetTextScale(XMFLOAT3(0.8f, 0.8f, 1.0f));
+        m_pPageText->SetFont(FontID::SFAutomatonExt);
 
 
         m_pPageUpButton = m_uiFactory.CreateChild<Button>(m_name + L"_PageUp", Float2(74, 66), XMFLOAT3(-100, -302, 0), 0, XMFLOAT3(1, 1, 1), UIDirection::LeftTop, this);

--- a/YunoGame/PhaseStaminaBar.cpp
+++ b/YunoGame/PhaseStaminaBar.cpp
@@ -30,8 +30,9 @@ void PhaseStaminaBar::CreateChild()
     //m_pGauge = m_uiFactory;
     m_pGauge = m_uiFactory.CreateChild<StaminaGauge>(m_name + L"_Gauge0", Float2(1077, 28), XMFLOAT3(0, 0, 0), UIDirection::Center, this);
     m_pGauge->SetFillDirection(FillDirection::LeftToRight);
+    m_pGauge->ChangeTexture(L"../Assets/UI/PLAY/Bar_STA_mirror.png"); // 목업 기준 사선이 오른쪽인 반전 텍스처 사용
 
-    m_pWeaponButton = m_uiFactory.CreateChild<PhaseWeaponSelectButton>(m_name + L"_Button", Float2(230, 72), XMFLOAT3(-650, -15, 0), UIDirection::LeftTop, this);
+    m_pWeaponButton = m_uiFactory.CreateChild<PhaseWeaponSelectButton>(m_name + L"_Button", Float2(230, 72), XMFLOAT3(-762, -35, 0), UIDirection::LeftTop, this); // 텍스처 투명여백(8px) 감안, 게이지 왼쪽 끝에 밀착
 }
 
 bool PhaseStaminaBar::Start()

--- a/YunoGame/PhaseStaminaBar.h
+++ b/YunoGame/PhaseStaminaBar.h
@@ -22,7 +22,7 @@ public:
 
     PhaseWeaponSelectButton* GetWeponSelectButton() { if (m_pWeaponButton) return m_pWeaponButton; else return nullptr; }
 private:
-    bool CreateMaterial() override { return Widget::CreateMaterial(L"../Assets/UI/PLAY/Bar_base.png"); }  // 머테리얼 생성 (한 번만)
+    bool CreateMaterial() override { return Widget::CreateMaterial(L"../Assets/UI/PLAY/Bar_base_mirror.png"); }  // 머테리얼 생성 (한 번만). 목업 기준 사선이 오른쪽인 반전 텍스처 사용
 
 protected:
     PhaseWeaponSelectButton* m_pWeaponButton = nullptr;

--- a/YunoGame/PlayerIcon.cpp
+++ b/YunoGame/PlayerIcon.cpp
@@ -58,8 +58,8 @@ void PlayerIcon::SetPlayer(const IconData& idata)
     prevHp = maxHp;
     prevStamina = maxStamina;
 
-    m_hpText->SetText(std::to_wstring(prevHp) + L" / " + std::to_wstring(maxHp));
-    m_StaminaText->SetText(std::to_wstring(prevStamina) + L" / " + std::to_wstring(maxStamina));
+    m_hpText->SetText(std::to_wstring(prevHp) + L"/" + std::to_wstring(maxHp));
+    m_StaminaText->SetText(std::to_wstring(prevStamina) + L"/" + std::to_wstring(maxStamina));
 }
 
 void PlayerIcon::SetWeapon(int weaponID)
@@ -128,7 +128,7 @@ void PlayerIcon::UpdateHPValue(float dTime)
 
     float percent = curHp / maxHp;
     m_HpBar->SetGaugeValue((int)(percent * 100.0f));
-    m_hpText->SetText(std::to_wstring(static_cast<int>(curHp)) + L" / " + std::to_wstring(maxHp));
+    m_hpText->SetText(std::to_wstring(static_cast<int>(curHp)) + L"/" + std::to_wstring(maxHp));
 
     if (t >= 1.0f)
     {
@@ -159,7 +159,7 @@ void PlayerIcon::UpdateStaminaValue(float dTime)
 
     float percent = curStamina / maxStamina;
     m_StaminaBar->SetGaugeValue((int)(percent * 100.0f));
-    m_StaminaText->SetText(std::to_wstring(static_cast<int>(curStamina)) + L" / " + std::to_wstring(maxStamina));
+    m_StaminaText->SetText(std::to_wstring(static_cast<int>(curStamina)) + L"/" + std::to_wstring(maxStamina));
 
     if (t >= 1.0f)
     {

--- a/YunoGame/ResultScene.cpp
+++ b/YunoGame/ResultScene.cpp
@@ -22,6 +22,12 @@ bool ResultScene::OnCreateScene()
 
 void ResultScene::CreateUI()
 {
+    // 승리/패배/무승부 페이지 글씨 뒤 어두운 필터 (StandBy와 동일한 방식). 가장 먼저 생성 → 패널 뒤에 깔림
+    auto canvas = m_uiManager->GetCanvasSize();
+    CreateWidget<TextureImage>(L"ResultBackGround",
+        L"../Assets/UI/WEAPON_SELECT/black_background.png",
+        XMFLOAT3(canvas.x * 0.5f, canvas.y * 0.5f, 0), UIDirection::Center);
+
     const float baseX = ClientW / 2 + 960;
     const float baseY = ClientH / 2 + 540;
 


### PR DESCRIPTION
- PlayerIcon 체력·스태미나 숫자 포맷 "80/80" (공백 제거)
- 인벤토리 스태미나 게이지·무기탭에 반전 텍스처 적용 및 위치 정렬 (Bar_STA_mirror.png / Bar_base_mirror.png)
- 카드 페이지 번호: 폰트 SFAutomatonExt, 크기·위치 조정
- 카운트다운(3·2·1)·승리/패배/무승부 페이지에 어두운 배경 필터 추가
- FontID::SFAutomatonExt 폰트 등록 추가

주의: 아래 신규 에셋은 .gitignore로 커밋 제외 -> 공유 Assets(SVN/드라이브)에 함께 추가 필요
  - Assets/Font/SFAutomatonExt.spritefont  (없으면 RegisterFont 실패로 실행 불가)
  - Assets/UI/PLAY/Bar_STA_mirror.png
  - Assets/UI/PLAY/Bar_base_mirror.png
  - Assets/Scenes/PlayHUDScene.json, PhaseUIScene.json (위치/스케일 조정분)

## 📌 Summary (변경 요약)
- 변경 목적:
- 핵심 변경 내용:

---

## 🧩 Type of Change
해당되는 항목에 체크하세요.

- [ ] Feature (새 기능)
- [x] Bug fix (버그 수정)
- [ ] Refactor (리팩토링)
- [ ] Chore (빌드/설정/구조 정리)
- [ ] Docs (문서 수정)

---

## 🔁 How to Test
1. 
2. 
3. 

---

## ✅ Checklist
- [ ] 빌드 성공
- [ ] 테스트 코드 및 불필요한 로그 제거
- [ ] 전방 선언 및 헤더 인클루드 점검
- [ ] 실행 테스트 완료 (Debug)
- [ ] 실행 테스트 완료 (Release)
