### PR TITLE
잔버그 수정

### DIFF
--- a/Launchers/YunoClient1Launcher.vcxproj
+++ b/Launchers/YunoClient1Launcher.vcxproj
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{9888A91C-7618-4E8B-BB29-412026C742A5}</ProjectGuid>
+    <Keyword>MakeFileProj</Keyword>
+    <RootNamespace>YunoClient1Launcher</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <YunoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..'))</YunoRoot>
+    <NMakeBuildCommandLine>cmd /c exit 0</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>cmd /c exit 0</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>cmd /c exit 0</NMakeCleanCommandLine>
+    <NMakeOutput>$(YunoRoot)\Bin\$(Platform)\$(Configuration)\Game\YunoGame.exe</NMakeOutput>
+    <LocalDebuggerCommand>$(YunoRoot)\Bin\$(Platform)\$(Configuration)\Game\YunoGame.exe</LocalDebuggerCommand>
+    <LocalDebuggerWorkingDirectory>$(YunoRoot)\Bin\$(Platform)\$(Configuration)\Game</LocalDebuggerWorkingDirectory>
+    <LocalDebuggerEnvironment>YUNO_SERVER_HOST=127.0.0.1
+YUNO_SERVER_PORT=9000
+YUNO_USER_ID=1</LocalDebuggerEnvironment>
+    <LocalDebuggerMergeEnvironment>true</LocalDebuggerMergeEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/Launchers/YunoClient2Launcher.vcxproj
+++ b/Launchers/YunoClient2Launcher.vcxproj
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{E975864E-15D6-452D-9CB1-002C182DB14C}</ProjectGuid>
+    <Keyword>MakeFileProj</Keyword>
+    <RootNamespace>YunoClient2Launcher</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <YunoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..'))</YunoRoot>
+    <NMakeBuildCommandLine>cmd /c exit 0</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>cmd /c exit 0</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>cmd /c exit 0</NMakeCleanCommandLine>
+    <NMakeOutput>$(YunoRoot)\Bin\$(Platform)\$(Configuration)\Game\YunoGame.exe</NMakeOutput>
+    <LocalDebuggerCommand>$(YunoRoot)\Bin\$(Platform)\$(Configuration)\Game\YunoGame.exe</LocalDebuggerCommand>
+    <LocalDebuggerWorkingDirectory>$(YunoRoot)\Bin\$(Platform)\$(Configuration)\Game</LocalDebuggerWorkingDirectory>
+    <LocalDebuggerEnvironment>YUNO_SERVER_HOST=127.0.0.1
+YUNO_SERVER_PORT=9000
+YUNO_USER_ID=2</LocalDebuggerEnvironment>
+    <LocalDebuggerMergeEnvironment>true</LocalDebuggerMergeEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/YunoEngine.sln
+++ b/YunoEngine.sln
@@ -27,6 +27,16 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "YunoImGui", "YunoImGui\Yuno
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "YunoNetTransport", "YunoNetTransport\YunoNetTransport.vcxproj", "{3C413F28-750C-49A2-AE7C-CC0CABD4650E}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "YunoClient1Launcher", "Launchers\YunoClient1Launcher.vcxproj", "{9888A91C-7618-4E8B-BB29-412026C742A5}"
+	ProjectSection(ProjectDependencies) = postProject
+		{6F20F6E3-AB1D-4D58-B117-1AA018D32777} = {6F20F6E3-AB1D-4D58-B117-1AA018D32777}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "YunoClient2Launcher", "Launchers\YunoClient2Launcher.vcxproj", "{E975864E-15D6-452D-9CB1-002C182DB14C}"
+	ProjectSection(ProjectDependencies) = postProject
+		{6F20F6E3-AB1D-4D58-B117-1AA018D32777} = {6F20F6E3-AB1D-4D58-B117-1AA018D32777}
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -83,6 +93,22 @@ Global
 		{3C413F28-750C-49A2-AE7C-CC0CABD4650E}.Release|x64.Build.0 = Release|x64
 		{3C413F28-750C-49A2-AE7C-CC0CABD4650E}.Release|x86.ActiveCfg = Release|Win32
 		{3C413F28-750C-49A2-AE7C-CC0CABD4650E}.Release|x86.Build.0 = Release|Win32
+		{9888A91C-7618-4E8B-BB29-412026C742A5}.Debug|x64.ActiveCfg = Debug|x64
+		{9888A91C-7618-4E8B-BB29-412026C742A5}.Debug|x64.Build.0 = Debug|x64
+		{9888A91C-7618-4E8B-BB29-412026C742A5}.Debug|x86.ActiveCfg = Debug|Win32
+		{9888A91C-7618-4E8B-BB29-412026C742A5}.Debug|x86.Build.0 = Debug|Win32
+		{9888A91C-7618-4E8B-BB29-412026C742A5}.Release|x64.ActiveCfg = Release|x64
+		{9888A91C-7618-4E8B-BB29-412026C742A5}.Release|x64.Build.0 = Release|x64
+		{9888A91C-7618-4E8B-BB29-412026C742A5}.Release|x86.ActiveCfg = Release|Win32
+		{9888A91C-7618-4E8B-BB29-412026C742A5}.Release|x86.Build.0 = Release|Win32
+		{E975864E-15D6-452D-9CB1-002C182DB14C}.Debug|x64.ActiveCfg = Debug|x64
+		{E975864E-15D6-452D-9CB1-002C182DB14C}.Debug|x64.Build.0 = Debug|x64
+		{E975864E-15D6-452D-9CB1-002C182DB14C}.Debug|x86.ActiveCfg = Debug|Win32
+		{E975864E-15D6-452D-9CB1-002C182DB14C}.Debug|x86.Build.0 = Debug|Win32
+		{E975864E-15D6-452D-9CB1-002C182DB14C}.Release|x64.ActiveCfg = Release|x64
+		{E975864E-15D6-452D-9CB1-002C182DB14C}.Release|x64.Build.0 = Release|x64
+		{E975864E-15D6-452D-9CB1-002C182DB14C}.Release|x86.ActiveCfg = Release|Win32
+		{E975864E-15D6-452D-9CB1-002C182DB14C}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/YunoEngine.slnLaunch
+++ b/YunoEngine.slnLaunch
@@ -1,13 +1,17 @@
 [
   {
-    "Name": "새 프로필",
+    "Name": "Server + Client 1 + Client 2",
     "Projects": [
       {
         "Path": "YunoServer\\YunoServer.vcxproj",
         "Action": "Start"
       },
       {
-        "Path": "YunoGame\\YunoGame.vcxproj",
+        "Path": "Launchers\\YunoClient1Launcher.vcxproj",
+        "Action": "Start"
+      },
+      {
+        "Path": "Launchers\\YunoClient2Launcher.vcxproj",
         "Action": "Start"
       }
     ]

--- a/YunoEngine/YunoEngine.vcxproj
+++ b/YunoEngine/YunoEngine.vcxproj
@@ -24,6 +24,7 @@
     <ProjectGuid>{ceb210f1-5107-40e0-a0cc-207c920418b6}</ProjectGuid>
     <RootNamespace>YunoEngine</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <VCToolsVersion Condition="'$(VCToolsVersion)'==''">14.44.35207</VCToolsVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/YunoGame/AddCardPanel.cpp
+++ b/YunoGame/AddCardPanel.cpp
@@ -62,6 +62,9 @@ void AddCardPanel::CreateChild()
 void AddCardPanel::SetCandidateCards(const std::vector<ClientCardInfo>& cards)
 {
     m_candidates = cards;
+    m_selectionTimer = 0.f;
+    m_closeTimer = 0.f;
+    m_locked = false;
 
     for (auto* btn : m_addCard)
     {
@@ -110,6 +113,7 @@ void AddCardPanel::OnCardSelected(int index)
 
 void AddCardPanel::Show()
 {
+    m_selectionTimer = 0.f;
     SetVisible(Visibility::Visible);
 
     if (m_bg)
@@ -138,24 +142,31 @@ void AddCardPanel::Hide()
 
 bool AddCardPanel::Update(float dt)
 {
-    if (m_locked)
+    auto& gameManager = GameManager::Get();
+
+    if (!m_locked && !m_candidates.empty())
     {
+        m_selectionTimer += dt;
+        if (m_selectionTimer >= m_selectionTimeout)
+        {
+            std::cout << "[Client] Bonus card selection timeout. Selecting index 0.\n";
+            OnCardSelected(0);
+        }
+    }
+
+    if (m_locked)
         m_closeTimer += dt;
 
-        if (m_closeTimer >= m_closeDelay)
-        {
-            Hide();
-            
-            if (GameManager::Get().GetEndTrun())
-            {
-                GameManager::Get().SetSceneState(CurrentSceneState::SubmitCard);
-                GameManager::Get().SetEndTrun(false);
-            }
-                
-            // 상태 리셋
-            m_locked = false;
-            m_selectedIndex = -1;
-        }
+    // Keep the existing selection effect for manual choices. If the server
+    // selected on timeout, there is no local lock and the transition is immediate.
+    const bool selectionEffectFinished = !m_locked || m_closeTimer >= m_closeDelay;
+    if (gameManager.GetEndTrun() && selectionEffectFinished)
+    {
+        Hide();
+        gameManager.SetEndTrun(false);
+        m_locked = false;
+        m_selectedIndex = -1;
+        gameManager.SetSceneState(CurrentSceneState::SubmitCard);
     }
     return Widget::Update(dt);
 }

--- a/YunoGame/AddCardPanel.h
+++ b/YunoGame/AddCardPanel.h
@@ -38,4 +38,6 @@ private:
     bool m_locked = false;       // 클릭 잠금
     float m_closeTimer = 0.f;    // 닫기 타이머
     float m_closeDelay = 3.f;    // 3초 유지
+    float m_selectionTimer = 0.f;
+    float m_selectionTimeout = 15.f;
 };

--- a/YunoGame/ClientNetwork/YunoClientNetwork.cpp
+++ b/YunoGame/ClientNetwork/YunoClientNetwork.cpp
@@ -521,7 +521,9 @@ namespace yuno::game
                 gm.AddCards(added);
                 gm.ClearDrawCandidates();
                 gm.ClearCardQueue();
-                gm.SetEndTrun(true);
+                // Turn 1 has no bonus-card selection screen. Only later turns
+                // should release AddCardPanel after both players have selected.
+                gm.SetEndTrun(pkt.turnNumber != 1);
 
                 for (int i = 0; i < 2; ++i)
                 {
@@ -560,7 +562,8 @@ namespace yuno::game
                 std::cout << "=============================\n";
                 std::cout << "[Client] S2C_EndGame received\n";
 
-                GameManager::Get().SetBattleOngoing(false);
+                auto& gm = GameManager::Get();
+                gm.SetBattleOngoing(false);
 
                 for (int i = 0; i < 2; ++i)
                 {
@@ -579,22 +582,25 @@ namespace yuno::game
                 if (p1Wins > p2Wins)
                 {
                     winnerPID = 1;
+                    gm.SetRoundResult(RoundResult::Winner_P1);
                     std::cout << "[Result] Player 1 WIN\n";
                 }
                 else if (p1Wins < p2Wins)
                 {
                     winnerPID = 2;
+                    gm.SetRoundResult(RoundResult::Winner_P2);
                     std::cout << "[Result] Player 2 WIN\n";
                 }   
                 else
                 {
                     winnerPID = -1;
+                    gm.SetRoundResult(RoundResult::Draw);
                     std::cout << "[Result] DRAW\n";
                 }
                 std::cout << "=============================\n";
 
-                GameManager::Get().SetWinnerPID(winnerPID);
-                GameManager::Get().SetEndGame(true);
+                gm.SetWinnerPID(winnerPID);
+                gm.SetEndGame(true);
             }
         );// S2C_EndGame Packet End
 

--- a/YunoGame/Game/GameApp.cpp
+++ b/YunoGame/Game/GameApp.cpp
@@ -83,7 +83,7 @@ bool GameApp::OnInit()
 
    //sm->RequestReplaceRoot(std::make_unique<PlayMidScene>(), opt);
    sm->RequestReplaceRoot(std::make_unique<Title>(), opt); 
-   /*{
+   /* {
        sm->RequestReplaceRoot(std::make_unique<PlayScene>(), opt);
        sm->RequestPush(std::make_unique<PlayHUDScene>());
    }*/

--- a/YunoGame/GameManager/GameManager.h
+++ b/YunoGame/GameManager/GameManager.h
@@ -173,7 +173,11 @@ public:
 
     int GetCurrentRound() const { return m_currentRound; }
     void IncreaseRound() { ++m_currentRound; }
-    void ResetRound() { m_currentRound = 0; }
+    void ResetRound()
+    {
+        m_currentRound = 0;
+        m_roundResult = RoundResult::None;
+    }
 
     int GetCurrentTurn() const { return m_currentTurn; }
     uint64_t GetTurnStateVersion() const { return m_turnStateVersion; }

--- a/YunoGame/PlayMidScene.cpp
+++ b/YunoGame/PlayMidScene.cpp
@@ -189,6 +189,11 @@ void PlayMidScene::CreateCoinTossUI()
 
 void PlayMidScene::ChangeUIState(PlayMidUIState state)
 {
+    // The server sends EndGame as soon as a player is eliminated. Keep the
+    // battle/reveal presentation, but never open bonus-card selection afterward.
+    if (state == PlayMidUIState::AddCardSelect && GameManager::Get().GetEndGame())
+        state = PlayMidUIState::Finished;
+
     if (m_uiState == state) return;
 
     Clear();
@@ -435,7 +440,9 @@ void PlayMidScene::UpdateRevealCard(float dt, GameManager& gm)
         if (m_postRevealTimer >= m_postRevealDelay)
         {
             ResetAllCardsToBack();
-            ChangeUIState(PlayMidUIState::AddCardSelect);
+            ChangeUIState(gm.GetEndGame()
+                ? PlayMidUIState::Finished
+                : PlayMidUIState::AddCardSelect);
         }
     }
 }
@@ -570,6 +577,11 @@ void PlayMidScene::Update(float dt)
     {
         ChangeUIState(PlayMidUIState::RevealCard);
     }
+
+    // Defensive path for an EndGame packet arriving after the selection panel
+    // has already opened in the same frame.
+    if (gm.GetEndGame() && m_uiState == PlayMidUIState::AddCardSelect)
+        ChangeUIState(PlayMidUIState::Finished);
 
     switch (m_uiState)
     {

--- a/YunoGame/Scenes/PlayHUDScene.cpp
+++ b/YunoGame/Scenes/PlayHUDScene.cpp
@@ -44,8 +44,9 @@ bool PlayHUDScene::OnCreateScene()
 
     //WinLose
     roundWin[0] = CreateWidget<TextureImage>(L"RoundCount", L"../Assets/UI/PLAY/3player_yet.png", XMFLOAT3(0, 0, 0));
-    roundWin[1] = CreateWidget<TextureImage>(L"RoundCount", L"../Assets/UI/PLAY/3player_yet.png", XMFLOAT3(0, 0, 0));
-    roundWin[2] = CreateWidget<TextureImage>(L"RoundCount", L"../Assets/UI/PLAY/3player_yet.png", XMFLOAT3(0, 0, 0));
+    // Only round one is playable. Keep the other two boxes as disabled gray placeholders.
+    roundWin[1] = CreateWidget<TextureImage>(L"RoundCount1", L"../Assets/UI/PLAY/4player_draw.png", XMFLOAT3(0, 0, 0));
+    roundWin[2] = CreateWidget<TextureImage>(L"RoundCount2", L"../Assets/UI/PLAY/4player_draw.png", XMFLOAT3(0, 0, 0));
 
     m_playerIcons[0] = CreateWidget<PlayerIcon>(L"PlayerIcon", Float2(130, 100), XMFLOAT3(700, 500, 0), UIDirection::Center);
     m_playerIcons[1] = CreateWidget<PlayerIcon>(L"PlayerIcon", Float2(130, 100), XMFLOAT3(700, 500, 0), UIDirection::Center);
@@ -312,30 +313,28 @@ bool PlayHUDScene::CheckRoundOver()
     return !isRoundReset;
 }
 
-void PlayHUDScene::ResetRound()
+void PlayHUDScene::ApplyRoundMarker()
 {
     if (isRoundReset)
         return;
 
     auto& gm = GameManager::Get();
+    constexpr size_t playableRoundMarker = 0;
 
     switch (gm.GetRoundResult())
     {
     case RoundResult::Winner_P1:
-        roundWin[curRound - 2]->ChangeTexture(L"../Assets/UI/PLAY/2player_win_blick.png");
+        roundWin[playableRoundMarker]->ChangeTexture(L"../Assets/UI/PLAY/2player_win_blick.png");
         break;
     case RoundResult::Winner_P2:
-        roundWin[curRound - 2]->ChangeTexture(L"../Assets/UI/PLAY/1player_win_blink.png");
+        roundWin[playableRoundMarker]->ChangeTexture(L"../Assets/UI/PLAY/1player_win_blink.png");
         break;
     case RoundResult::Draw:
-        roundWin[curRound - 2]->ChangeTexture(L"../Assets/UI/PLAY/4player_draw.png");
+        roundWin[playableRoundMarker]->ChangeTexture(L"../Assets/UI/PLAY/4player_draw.png");
         break;
     default:
-        roundWin[curRound - 2]->ChangeTexture(L"../Assets/UI/PLAY/4player_draw_blink.png"); //디버그용 뜨면 버그인거임
-        break;
+        return;
     }
-
-    gm.ResetTurn();
 
     isRoundReset = true;
 }
@@ -344,7 +343,7 @@ void PlayHUDScene::ChangeRound(float dt)
 {
     if (m_SceneChange->IsFinished() && !m_isRoundChangeReverse && !m_hasRoundChangeSignalSent)
     {
-        ResetRound();
+        ApplyRoundMarker();
         m_SceneChange->SetReverse(true);
         m_SceneChange->Stop();
         GameManager::Get().SetRoundChangeNow();
@@ -374,6 +373,10 @@ void PlayHUDScene::Update(float dt)
 
     auto& gm = GameManager::Get();
     auto scenestate = gm.GetSceneState();
+
+    // A one-round match never increments to round two, so apply the result
+    // marker directly when the authoritative EndGame result arrives.
+    ApplyRoundMarker();
 
     if (m_appliedTurnStateVersion != gm.GetTurnStateVersion())
     {

--- a/YunoGame/Scenes/PlayHUDScene.h
+++ b/YunoGame/Scenes/PlayHUDScene.h
@@ -40,7 +40,7 @@ protected:
     void RefreshTurnTexture();
 
     bool CheckRoundOver();
-    void ResetRound();
+    void ApplyRoundMarker();
 
 private:
     PlayHUD_InputContext m_uiContext;

--- a/YunoGame/System/PlayGridSystem.cpp
+++ b/YunoGame/System/PlayGridSystem.cpp
@@ -1277,7 +1277,6 @@ void PlayGridSystem::ApplyObstacleResult(const ObstacleResult& obstacle)
     }
     //std::cout << std::endl;
 
-    bool hasTriggerSnapshot = false;
     Float4 warnColor{ 1.0f, 0.0f, 0.0f, 1.f };
 
 
@@ -1311,7 +1310,6 @@ void PlayGridSystem::ApplyObstacleResult(const ObstacleResult& obstacle)
         if (prev.hp != cur.hp)
         {
             os.hitPieces.push_back(piece);
-            hasTriggerSnapshot = true;
         }
 
 
@@ -1350,10 +1348,8 @@ void PlayGridSystem::ApplyObstacleResult(const ObstacleResult& obstacle)
         os.hitTileIDs = m_obstacleTile.tileIDs;
     }
 
-    if (hasTriggerSnapshot) // 누군가 맞은 애 있으면 obstacle 패킷에서 받은 스냅샷으로 현재 유닛 상태 변경
-    {
-        m_UnitStates = obstacle.unitState;
-    }
+    // 피해 유무와 관계없이 스태미나 회복을 포함한 서버 턴 경계 스냅샷을 적용한다.
+    m_UnitStates = obstacle.unitState;
 
 
     // 다음 장애물 경고    // 이펙트 넣기★

--- a/YunoGame/YunoGame.vcxproj
+++ b/YunoGame/YunoGame.vcxproj
@@ -24,6 +24,7 @@
     <ProjectGuid>{6f20f6e3-ab1d-4d58-b117-1aa018d32777}</ProjectGuid>
     <RootNamespace>YunoGame</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <VCToolsVersion Condition="'$(VCToolsVersion)'==''">14.44.35207</VCToolsVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/YunoImGui/YunoImGui.vcxproj
+++ b/YunoImGui/YunoImGui.vcxproj
@@ -47,6 +47,7 @@
     <ProjectGuid>{ce3886a1-acc6-4b3e-b173-4ffdeb44e0fb}</ProjectGuid>
     <RootNamespace>YunoImGui</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <VCToolsVersion Condition="'$(VCToolsVersion)'==''">14.44.35207</VCToolsVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/YunoNetProtocol/YunoNetProtocol.vcxproj
+++ b/YunoNetProtocol/YunoNetProtocol.vcxproj
@@ -24,6 +24,7 @@
     <ProjectGuid>{69684c5f-323b-4bbf-8e8f-ee62bf0eca13}</ProjectGuid>
     <RootNamespace>YunoNetProtocol</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <VCToolsVersion Condition="'$(VCToolsVersion)'==''">14.44.35207</VCToolsVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/YunoNetTransport/YunoNetTransport.vcxproj
+++ b/YunoNetTransport/YunoNetTransport.vcxproj
@@ -24,6 +24,7 @@
     <ProjectGuid>{3c413f28-750c-49a2-ae7c-cc0cabd4650e}</ProjectGuid>
     <RootNamespace>YunoNetTransport</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <VCToolsVersion Condition="'$(VCToolsVersion)'==''">14.44.35207</VCToolsVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/YunoServer/BattleState.h
+++ b/YunoServer/BattleState.h
@@ -48,10 +48,11 @@ namespace yuno::server
         PlayerBattleState players[2];   // [0] = P1, [1] = P2
         int turnNumber = 0;
     
-        // 3판 2선승제용 상태
+        // A match is intentionally limited to a single round.
         uint8_t roundWins[2] = { 0, 0 }; // [0] = P1, [1] = P2
         uint8_t currentRound = 1;
-        uint8_t winsToFinish = 2;
+        uint8_t winsToFinish = 1;
+        uint8_t maxRounds = 1;
 
         bool roundEnded = false;
         uint8_t roundWinnerPID = 0; // 0 = 무승부/미결
@@ -62,7 +63,9 @@ namespace yuno::server
 
         bool CheckMatchEnd() // 최종 승자 나왔는지 체크
         {
-            return roundWins[0] == 2 || roundWins[1] == 2;
+            return roundWins[0] >= winsToFinish ||
+                roundWins[1] >= winsToFinish ||
+                (roundEnded && currentRound >= maxRounds);
         }
     };
 

--- a/YunoServer/RoundController.cpp
+++ b/YunoServer/RoundController.cpp
@@ -12,6 +12,7 @@
 #include "S2C_CardPackets.h"
 #include "S2C_EndGame.h"
 #include "S2C_EndGame_Disconnect.h"
+#include <algorithm>
 #include <iostream>
 
 namespace yuno::server
@@ -30,6 +31,18 @@ namespace yuno::server
 
     void RoundController::Update()
     {
+        if (m_waitingCardSelection &&
+            std::chrono::steady_clock::now() >= m_cardSelectionDeadline)
+        {
+            std::cout << "[Round] Bonus card selection timeout. Auto-selecting.\n";
+
+            for (int playerIdx = 0; playerIdx < 2 && m_waitingCardSelection; ++playerIdx)
+            {
+                if (!m_cardSelected[playerIdx])
+                    AutoSelectBonusCard(playerIdx);
+            }
+        }
+
         if (!m_waitingRoundStartReady)
             return;
 
@@ -234,8 +247,12 @@ namespace yuno::server
 
         m_roundStarted = false;
 
-        if (g_battleState.matchEnded || g_battleState.currentRound > 3)
+        if (g_battleState.matchEnded ||
+            g_battleState.currentRound >= g_battleState.maxRounds)
         {
+            g_battleState.matchEnded = true;
+            if (g_battleState.matchWinnerPID == 0)
+                g_battleState.matchWinnerPID = g_battleState.roundWinnerPID;
             EndGame();
             return;
         }
@@ -258,17 +275,8 @@ namespace yuno::server
 
     void RoundController::StartTurn()
     {
-
-        //auto recoverUnitStamina = [](UnitState& unit)
-        //    {
-        //        const int recovered = static_cast<int>(unit.stamina) + 10;
-        //        unit.stamina = static_cast<uint8_t>(std::min(recovered, static_cast<int>(unit.maxStamina)));
-        //    };
-
-        //recoverUnitStamina(g_battleState.players[0].unit1);
-        //recoverUnitStamina(g_battleState.players[0].unit2);
-        //recoverUnitStamina(g_battleState.players[1].unit1);
-        //recoverUnitStamina(g_battleState.players[1].unit2);
+        // Stamina is recovered after obstacle resolution at the turn boundary,
+        // so S2C_ObstacleResult and the authoritative server state stay identical.
 
         yuno::net::packets::S2C_StartTurn pkt{};
         pkt.turnNumber = ++g_battleState.turnNumber;        // 1턴부터 시작
@@ -281,8 +289,21 @@ namespace yuno::server
 
         if (g_battleState.turnNumber != 1)
         {
-            pkt.addedCards[0] = g_battleState.players[0].handCards.back();
-            pkt.addedCards[1] = g_battleState.players[1].handCards.back();
+            for (int playerIdx = 0; playerIdx < 2; ++playerIdx)
+            {
+                const uint32_t runtimeId = m_selectedBonusRuntimeIds[playerIdx];
+                const auto& handCards = g_battleState.players[playerIdx].handCards;
+                const auto selectedCard = std::find_if(
+                    handCards.begin(),
+                    handCards.end(),
+                    [runtimeId](const auto& card)
+                    {
+                        return runtimeId != 0 && card.runtimeID == runtimeId;
+                    });
+
+                if (selectedCard != handCards.end())
+                    pkt.addedCards[playerIdx] = *selectedCard;
+            }
         }
 
 
@@ -294,6 +315,8 @@ namespace yuno::server
             });
 
         m_network.Broadcast(std::move(bytes));
+        m_waitingCardSelection = false;
+        m_selectedBonusRuntimeIds.fill(0);
         std::cout << "==================S2C_StartTurn Broadcast==================" << std::endl;
     }
 
@@ -309,8 +332,19 @@ namespace yuno::server
         }
         m_cardSelected[0] = false;
         m_cardSelected[1] = false;
+        m_selectedBonusRuntimeIds.fill(0);
 
         SendDrawCandidates();
+        m_waitingCardSelection = true;
+        m_cardSelectionDeadline =
+            std::chrono::steady_clock::now() + kCardSelectionTimeout;
+
+        // An empty candidate list must not block the next turn.
+        for (int playerIdx = 0; playerIdx < 2 && m_waitingCardSelection; ++playerIdx)
+        {
+            if (g_battleState.players[playerIdx].drawCandidates.empty())
+                AutoSelectBonusCard(playerIdx);
+        }
         //종료 플래그 이미 받은 상태
         //턴스타트 라운드엔드
 
@@ -382,6 +416,8 @@ namespace yuno::server
         m_roundStartReady[1] = false;
         m_cardSelected[0] = false;
         m_cardSelected[1] = false;
+        m_selectedBonusRuntimeIds.fill(0);
+        m_waitingCardSelection = false;
 
         g_battleState.turnNumber = 0;
         g_battleState.roundWins[0] = 0;
@@ -410,8 +446,12 @@ namespace yuno::server
     
     void RoundController::OnPlayerSelectedCard(int playerIdx)
     {
-        if (m_cardSelected[playerIdx])
-            return; // 중복 선택 방지
+        if (!CanSelectBonusCard(playerIdx))
+            return;
+
+        const auto& handCards = g_battleState.players[playerIdx].handCards;
+        if (!handCards.empty())
+            m_selectedBonusRuntimeIds[playerIdx] = handCards.back().runtimeID;
 
         m_cardSelected[playerIdx] = true;
 
@@ -423,5 +463,46 @@ namespace yuno::server
         {
             StartTurn();
         }
+    }
+
+    bool RoundController::CanSelectBonusCard(int playerIdx) const
+    {
+        return playerIdx >= 0 && playerIdx < 2 &&
+            m_waitingCardSelection && !m_cardSelected[playerIdx];
+    }
+
+    void RoundController::AutoSelectBonusCard(int playerIdx)
+    {
+        if (playerIdx < 0 || playerIdx > 1 || m_cardSelected[playerIdx])
+            return;
+
+        auto& player = g_battleState.players[playerIdx];
+        if (player.drawCandidates.empty())
+        {
+            m_selectedBonusRuntimeIds[playerIdx] = 0;
+            m_cardSelected[playerIdx] = true;
+            std::cout << "[Round] Player " << playerIdx
+                << " has no bonus card candidates.\n";
+
+            if (m_cardSelected[0] && m_cardSelected[1])
+                StartTurn();
+            return;
+        }
+
+        const uint32_t runtimeId = player.drawCandidates.front().runtimeID;
+        if (!m_cardController.SelectCard(player, runtimeId))
+        {
+            std::cout << "[Round] Failed to auto-select bonus card for player "
+                << playerIdx << "\n";
+
+            // Even a malformed candidate list must not block the match forever.
+            m_selectedBonusRuntimeIds[playerIdx] = 0;
+            m_cardSelected[playerIdx] = true;
+            if (m_cardSelected[0] && m_cardSelected[1])
+                StartTurn();
+            return;
+        }
+
+        OnPlayerSelectedCard(playerIdx);
     }
 }

--- a/YunoServer/RoundController.h
+++ b/YunoServer/RoundController.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <array>
+#include <chrono>
 #include <unordered_map>
 
 namespace yuno::server
@@ -23,6 +25,7 @@ namespace yuno::server
         void EndTurn();
         void EndGame();
         void OnPlayerSelectedCard(int playerIdx);
+        bool CanSelectBonusCard(int playerIdx) const;
         void ResetMatchState();
 
         void EndGameByDisconnect(uint8_t winnerPID, uint32_t winnerSessionId);
@@ -39,6 +42,7 @@ namespace yuno::server
         void SendInitialCards();
         void SendRoundStart();
         void SendDrawCandidates();
+        void AutoSelectBonusCard(int playerIdx);
 
         void StartTurn();
         
@@ -57,6 +61,13 @@ namespace yuno::server
         bool m_roundStartReady[2] = { false, false };
 
         bool m_cardSelected[2] = { false, false };
+        std::array<uint32_t, 2> m_selectedBonusRuntimeIds{};
+        bool m_waitingCardSelection = false;
+        std::chrono::steady_clock::time_point m_cardSelectionDeadline{};
+
+        // The server starts this clock before clients finish battle playback.
+        // Keep a generous fail-safe; the client auto-selects 15 seconds after its UI opens.
+        static constexpr std::chrono::seconds kCardSelectionTimeout{ 90 };
         std::unordered_map<uint32_t, uint8_t> m_unitIdMap;
     };
 }

--- a/YunoServer/ServerNetwork/YunoServerNetwork.cpp
+++ b/YunoServer/ServerNetwork/YunoServerNetwork.cpp
@@ -515,6 +515,11 @@ namespace yuno::server
 
                 auto& player = g_battleState.players[idx];
 
+                // Ignore packets that arrive after the timeout already advanced
+                // the turn; otherwise a late selection could mutate the new hand.
+                if (!m_roundController.CanSelectBonusCard(idx))
+                    return;
+
                 std::cout
                     << "[Server] C2S_SelectCard received"
                     << " SessionID=" << peer.sId
@@ -610,7 +615,6 @@ namespace yuno::server
                 g_battleState.roundWins[winnerPID - 1]++;
 
                 // 라운드 번호 증가
-                g_battleState.currentRound++;
 
                 //매치 종료 여부 체크
                 if (g_battleState.roundWins[0] >= g_battleState.winsToFinish)
@@ -623,6 +627,9 @@ namespace yuno::server
                     g_battleState.matchEnded = true;
                     g_battleState.matchWinnerPID = 2;
                 }
+
+                if (!g_battleState.matchEnded)
+                    g_battleState.currentRound++;
 
                 m_roundController.EndRound();
             }

--- a/YunoServer/TurnManager.cpp
+++ b/YunoServer/TurnManager.cpp
@@ -418,6 +418,12 @@ namespace yuno::server
                     g_battleState.matchEnded = true;
                     g_battleState.matchWinnerPID = 2;
                 }
+                else if (g_battleState.currentRound >= g_battleState.maxRounds)
+                {
+                    // A simultaneous knockout in the only playable round ends the match as a draw.
+                    g_battleState.matchEnded = true;
+                    g_battleState.matchWinnerPID = 0;
+                }
 
                 if (!g_battleState.matchEnded)
                 {
@@ -1053,9 +1059,7 @@ namespace yuno::server
                     obstacleState.unitState[i].ownerSlot = static_cast<uint8_t>(ownerSlot);
                     obstacleState.unitState[i].unitLocalIndex = static_cast<uint8_t>(unitLocalIndex);
                     obstacleState.unitState[i].hp = units[i]->hp;
-                    const int boostedStamina = static_cast<int>(units[i]->stamina) + 10;
-                    obstacleState.unitState[i].stamina = static_cast<uint8_t>(
-                        std::min(boostedStamina, static_cast<int>(units[i]->maxStamina)));
+                    obstacleState.unitState[i].stamina = units[i]->stamina;
                     obstacleState.unitState[i].targetTileID = units[i]->tileID;
                     obstacleState.unitState[i].isEvent = damagedByObstacle[i] ? 1 : 0; // 장애물 패킷에서 isEvent는 장애물에 적중됐으면 T, 아니면 F
                 }
@@ -1127,11 +1131,28 @@ namespace yuno::server
                     g_battleState.matchEnded = true;
                     g_battleState.matchWinnerPID = 2;
                 }
+                else if (g_battleState.currentRound >= g_battleState.maxRounds)
+                {
+                    g_battleState.matchEnded = true;
+                    g_battleState.matchWinnerPID = 0;
+                }
 
                 if (!g_battleState.matchEnded)
                 {
                     g_battleState.currentRound = static_cast<uint8_t>(g_battleState.currentRound + 1);
                 }
+            }
+        }
+
+        // Recover once at the turn boundary, after obstacle damage has been resolved.
+        // The packet below then carries the exact authoritative stamina value.
+        if (!g_battleState.roundEnded)
+        {
+            for (UnitState* unit : units)
+            {
+                const int recovered = static_cast<int>(unit->stamina) + 20;
+                unit->stamina = static_cast<uint8_t>(
+                    std::min(recovered, static_cast<int>(unit->maxStamina)));
             }
         }
 

--- a/YunoServer/YunoServer.vcxproj
+++ b/YunoServer/YunoServer.vcxproj
@@ -24,6 +24,7 @@
     <ProjectGuid>{9585bf40-e4b6-4a74-9202-893d0377ede2}</ProjectGuid>
     <RootNamespace>YunoServer</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <VCToolsVersion Condition="'$(VCToolsVersion)'==''">14.44.35207</VCToolsVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
1. 1라운드 단판승으로 변경
2. 매치 종료시 카드선택 나오는 버그 수정했음
3. 클라1이 보너스 카드 선택 후 클라2가 선택 안하면 게임 진행안되는 버그 수정
4. 턴 종료시 스태미너20회복 추가

## 📌 Summary (변경 요약)
- 변경 목적: 잔버그 수정 및 기능 폴리싱
- 핵심 변경 내용: 3라운드제에서 1라운드제로 변경, 카드 선택 늦으면 진행안되는 치명적 버그 수정 + 15초 타임아웃 적용, 턴종료시 스태미너 회복 20으로 증가

---

## 🧩 Type of Change
해당되는 항목에 체크하세요.

- [ o ] Feature (새 기능)
- [ o ] Bug fix (버그 수정)
- [ o ] Refactor (리팩토링)
- [ ] Chore (빌드/설정/구조 정리)
- [ ] Docs (문서 수정)

---

## 🔁 How to Test
1. 디버그 실행 테스트
2. 
3. 

---

## ✅ Checklist
- [ o ] 빌드 성공
- [ ] 테스트 코드 및 불필요한 로그 제거
- [ ] 전방 선언 및 헤더 인클루드 점검
- [ o ] 실행 테스트 완료 (Debug)
- [ ] 실행 테스트 완료 (Release)
